### PR TITLE
[Balance] active_enemies check for vigil

### DIFF
--- a/balance.txt
+++ b/balance.txt
@@ -19,7 +19,7 @@ actions+=/potion,if=!druid.no_cds&(buff.ca_inc.remains>=20|variable.no_cd_talent
 actions+=/use_items,slots=trinket1,if=variable.on_use_trinket!=1&!trinket.2.ready_cooldown|(variable.on_use_trinket=1|variable.on_use_trinket=3)&buff.ca_inc.up|variable.no_cd_talent|fight_remains<20|variable.on_use_trinket=0
 actions+=/use_items,slots=trinket2,if=variable.on_use_trinket!=2&!trinket.1.ready_cooldown|variable.on_use_trinket=2&buff.ca_inc.up|variable.no_cd_talent|fight_remains<20|variable.on_use_trinket=0
 actions+=/use_items
-actions+=/natures_vigil
+actions+=/natures_vigil,if=active_enemies
 actions+=/invoke_external_buff,name=power_infusion
 actions+=/run_action_list,name=aoe,if=variable.is_aoe
 actions+=/run_action_list,name=st


### PR DESCRIPTION
In a Droute sim the sim will use vigil during downtime plottering the timeline with wait events before and after the use:

https://www.raidbots.com/simbot/report/84rSp3c3oxnzgLn7YnH9oc/simc